### PR TITLE
Small fixes to parsing & commenting

### DIFF
--- a/MapBasic_v120.tmLanguage
+++ b/MapBasic_v120.tmLanguage
@@ -186,8 +186,6 @@
 					<string>meta.separator.comma.mapbasic120</string>
 				</dict>
 			</dict>
-			<key>match</key>
-			<string>(?i:(dim)\s*(?:(\b[a-zA-Z_x7f-xff][a-zA-Z0-9_x7f-xff]*?\b)\s*(,?)))</string>
 			<key>name</key>
 			<string>variable.other.dim.mapbasic120</string>
 		</dict>

--- a/MapBasic_v120.tmPreferences
+++ b/MapBasic_v120.tmPreferences
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>scope</key>
+		<string>source.mapbasic120</string>
+		<key>settings</key>
+		<dict>
+			<key>icon</key>
+			<string>file_type_gruntfile</string>
+			<key>shellVariables</key>
+			<array>
+			  <dict>
+				<key>name</key>
+				<string>TM_COMMENT_START</string>
+				<key>value</key>
+				<string>' </string>
+			  </dict>
+			</array>
+		</dict>
+	</dict>
+</plist>


### PR DESCRIPTION
Changes:
1. Adding support for 'comment' functionality in Sublime Text
1. Removed regex which was incorrectly matching only on `var1` on statements such as
``` Dim var1, var2, var3 as Integer```
